### PR TITLE
[86b1n2fj4] Routing Framework

### DIFF
--- a/src/shared/DomainModel.fs
+++ b/src/shared/DomainModel.fs
@@ -3,6 +3,8 @@
 open System
 open System.Text.RegularExpressions
 
+type Marker = interface end
+
 [<Measure>]
 type mg // Milligram
 

--- a/src/shared/DomainModel.fs
+++ b/src/shared/DomainModel.fs
@@ -32,6 +32,8 @@ let emailAddress (ea: string) =
     else
         None
 
+type Url = string
+
 type AdPlatform =
     | Alphabet
     | Meta
@@ -90,8 +92,8 @@ type Product = {
     Plating: Material
     Price: MoneyAmount
     ProductionCost: MoneyAmount
-    Thumbnail: Uri
-    Assets: Uri list
+    Thumbnail: Url
+    Assets: Url list
     Category: ProductCategory
     Collection: ProductCollection
 }
@@ -114,7 +116,7 @@ type BrowserData = {
     Languages: string list
 }
 
-type PageLoadData = { PageUrl: Uri; Browser: BrowserData }
+type PageLoadData = { PageUrl: Url; Browser: BrowserData }
 
 type PositionData = { X: uint; Y: uint }
 

--- a/src/ui/Error.fs
+++ b/src/ui/Error.fs
@@ -1,0 +1,19 @@
+module Store.UI.Error
+
+open Feliz
+open type Feliz.Html
+open Browser.Dom
+
+type ErrorCode =
+    | PageNotFound
+    | InternalError
+
+[<ReactComponent>]
+let Error =
+    function
+    | PageNotFound ->
+        React.useEffectOnce (fun () -> document.title <- "404 - Page Not Found")
+        div [ h1 "Error - Page not found"; p "The requested page could not be found." ]
+    | InternalError ->
+        React.useEffectOnce (fun () -> document.title <- "500 - Internal Error")
+        div [ h1 "Internal Error"; p "The server encountered an error while processing your request." ]

--- a/src/ui/Root.fs
+++ b/src/ui/Root.fs
@@ -1,33 +1,21 @@
 module Store.UI.Root
 
-open System
 open Feliz
-open type Html
+open Feliz.Router
+open Store.UI.Error
 open Browser
 
 [<ReactComponent>]
 let Root () =
-    let name, setName = React.useState "Zori"
+    let (url, setUrl) = React.useState (Router.currentPath ())
 
-    let title =
-        if String.IsNullOrWhiteSpace(name) then
-            "Nobody"
-        else
-            name.ToUpperInvariant()
-        |> sprintf "%s's Site"
-
-    let paddedName =
-        if String.IsNullOrWhiteSpace name then
-            ""
-        else
-            sprintf " %s" name
-
-    React.useEffect ((fun () -> document.title <- title), [| box name |])
-
-    div [
-        h1 $"Hi{paddedName}! Welcome to your website!"
-        span "Name: "
-        input [ prop.value name; prop.onChange setName ]
+    React.router [
+        router.pathMode
+        router.onUrlChanged setUrl
+        router.children [
+            match url with
+            | _ -> Error PageNotFound
+        ]
     ]
 
 let reactRoot = ReactDOM.createRoot (document.getElementById "root")

--- a/src/ui/Store.UI.fsproj
+++ b/src/ui/Store.UI.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -6,9 +6,11 @@
     <DefaultNamespace>Store.UI</DefaultNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Error.fs" />
     <Compile Include="Root.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Feliz" Version="2.8.0" />
+    <PackageReference Include="Feliz.Router" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/test/DomainModel.fs
+++ b/test/DomainModel.fs
@@ -1,0 +1,26 @@
+module Store.Test.DomainModel
+
+open Xunit
+open Microsoft.FSharp.Reflection
+open Microsoft.FSharp.Quotations.Patterns
+open Store.Shared
+open System.Reflection
+
+let domainModel = typeof<DomainModel.Marker>.DeclaringType
+
+[<Fact>]
+let ``Domain Model is a Module`` () = FSharpType.IsModule domainModel
+
+[<Fact>]
+let ``Discriminated Unions Have Up To Five Cases`` () =
+    domainModel.GetNestedTypes(BindingFlags.Public)
+    |> Array.filter FSharpType.IsUnion
+    |> Array.map FSharpType.GetUnionCases
+    |> Array.iter (fun t -> Assert.InRange(t.Length, 1, 5))
+
+[<Fact>]
+let ``Records Have Up To Ten Members`` () =
+    domainModel.GetNestedTypes(BindingFlags.Public)
+    |> Array.filter FSharpType.IsRecord
+    |> Array.map FSharpType.GetRecordFields
+    |> Array.iter (fun t -> Assert.InRange(t.Length, 1, 10))

--- a/test/Store.Test.fsproj
+++ b/test/Store.Test.fsproj
@@ -7,6 +7,7 @@
     <DefaultNamespace>Store.Test</DefaultNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="DomainModel.fs" />
     <Compile Include="Meta.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
@@ -21,5 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../src/ui/Store.UI.fsproj" />
+    <ProjectReference Include="..\src\shared\Store.Shared.fsproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Type

`src`

# Summary

Adds basic routing with `Feliz.Router`, along with a default error page.

# Changes

* Created error page with 404 and 500 pages.
* Added the Feliz Router as a package.
* Set up Feliz routing in path mode.
* Added a test for the domain model.