### PR TITLE
UserAgentData Defaulting

### DIFF
--- a/src/ui/Root.fs
+++ b/src/ui/Root.fs
@@ -25,7 +25,7 @@ let Root () =
                 CorrelationId = correlationId <| uint64 0
                 Browser = navigator.userAgent
                 FormFactor =
-                    if (emitJsExpr () "navigator.userAgentData.mobile") then
+                    if (emitJsExpr () "(navigator.userAgentData?.mobile ?? false)") then
                         MobileBrowser
                     else
                         DesktopBrowser


### PR DESCRIPTION
# Type

`src`

# Summary

Hotfix.

# Changes

* Default to false if userAgentData is not available (e.g. in non-HTTPS contexts).