### PR TITLE
[86b2xhh3f] Material Name on Product Page

### DIFF
--- a/src/ui/Product.fs
+++ b/src/ui/Product.fs
@@ -84,7 +84,13 @@ let Product (product: Product) =
                     ]
 
                     ul [
-                        li [ sprintf "Material: %A" product.Plating |> text ]
+                        li [
+                            match product.Plating with
+                            | Gold14k -> "Gold-plated sterling silver"
+                            | WhiteGold14k -> "White gold-plated sterling silver"
+                            |> sprintf "Material: %s"
+                            |> text
+                        ]
                         li [
                             sprintf "Weight: %.1f g per pair" ((float product.Mass) * 1.0<mg> / 1000.0<mg / g>) |> text
                         ]


### PR DESCRIPTION
# Type

`src`

# Summary

Displays material names correctly.

# Changes

* Changed material name to be populated by an exhaustive case match instead of just stringifying the case label.